### PR TITLE
feat(update): add update by environment variable

### DIFF
--- a/src/ohsnap.zig
+++ b/src/ohsnap.zig
@@ -117,6 +117,17 @@ pub const Snap = struct {
     pub fn diff(snapshot: *const Snap, got: []const u8, test_it: bool) !void {
         // Check for an update first
         const update_idx = std.mem.indexOf(u8, snapshot.text, "<!update>");
+        const update_envvar = std.process.hasEnvVarConstant("SNAP_UPDATE");
+
+        if (update_envvar) {
+            const match = regex_finder.match(snapshot.text);
+            if (match) |_| {
+                return try patchAndUpdate(snapshot, got);
+            } else {
+                return try updateSnap(snapshot, got);
+            }
+        }
+
         if (update_idx) |idx| {
             if (idx == 0) {
                 const match = regex_finder.match(snapshot.text);


### PR DESCRIPTION
Added the second option to update a snapshot test with an environment variable very inspired by the original snapshot testing library from TigerBeetle (see [tigerbeetle/tigerbeetle/blob/main/src/testing/snaptest.zig#L109-L112](https://github.com/tigerbeetle/tigerbeetle/blob/bdc49c52bfd68f4caf564abcbf1e6adb9752fe28/src/testing/snaptest.zig#L109-L112)).

This option was, tested but a unit test is kind of useless in this case. The test included the update of the `CustomStruct` structure like shown in the code snippet below (first snippet before update, second commands, third after update):

```zig
test "update env var" {
    const oh = OhSnap{};
    const foobar = CustomStruct{ .foo = 42, .bar = 23 };
    try oh.snap(
        @src(),
        \\
        ,
    ).expectEqual(foobar);
}
```

```bash
# fail on test "update env var"
zig build test
# command to update
SNAP_UPDATE=1 zig build test
# "update env var" test passes
zig build test
```

```zig
test "update env var" {
    const oh = OhSnap{};
    const foobar = CustomStruct{ .foo = 42, .bar = 23 };
    try oh.snap(
        @src(),
        \\ohsnap.CustomStruct
        \\  .foo: u64 = 42
        \\  .bar: u66 = 23
        ,
    ).expectEqual(foobar);
}
```
PS: I know the code is a little bit repetitive if you have an idea how make it look nicer I'm open for changes.

PPS: I know this is out of the blue. I looked at snapshot testing, then the blog entry from TigerBeetle, then thought I could outsource the snap lib from, them then saw your project and missed this feature while using it hope you like it. Like the idea of this project very much ❤️!