### PR TITLE
Fix pretty dependency hash

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -32,7 +32,7 @@
         },
         .pretty = .{
             .url = "https://github.com/timfayz/pretty/archive/refs/heads/main.tar.gz",
-            .hash = "pretty-0.10.4-Tm65r5pKAQDdxCFNtL6huo7lHc_HWn6v4VO5WaTufpRQ",
+            .hash = "pretty-0.10.6-Tm65r6lPAQCBxgwzehYPeqsCXQDT9kt2ktJuO-2tRfE6",
         },
         .muad_diff = .{
             .url = "https://github.com/mnemnion/muad-diff/archive/refs/tags/ohsnap-prerelease-02.tar.gz",


### PR DESCRIPTION
I have a zig project with ohsnap in the build.zig.zon:

```zig
    .dependencies = .{
        .ohsnap = .{
            .url = "https://github.com/mnemnion/ohsnap/archive/refs/tags/v0.4.1.tar.gz",
            .hash = "ohsnap-0.4.1-iWxzyhicAAA90MEnwxA22VshYmsSH3t0dcqM9yib7ose",
        },
    },
```

When I run it, ohsnap refuses to build:

```bash
> zig build run
/home/pancelor/.cache/zig/p/ohsnap-0.4.1-iWxzyhicAAA90MEnwxA22VshYmsSH3t0dcqM9yib7ose/build.zig.zon:35:21: error: hash mismatch: manifest declares 'pretty-0.10.4-Tm65r5pKAQDdxCFNtL6huo7lHc_HWn6v4VO5WaTufpRQ' but the fetched package has 'pretty-0.10.6-Tm65r6lPAQCBxgwzehYPeqsCXQDT9kt2ktJuO-2tRfE6'
            .hash = "pretty-0.10.4-Tm65r5pKAQDdxCFNtL6huo7lHc_HWn6v4VO5WaTufpRQ",
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This commit should fix that temporarily, although it will break again once pretty gets more commits (b/c ohsnap is tracking main instead of a release)